### PR TITLE
SpinButton Fix

### DIFF
--- a/font.py
+++ b/font.py
@@ -244,8 +244,11 @@ class FontSize(Gtk.ToolItem):
         self._default_size = 14
         self._font_size = self._default_size
 
-        self._size_label = Gtk.Label(str(self._font_size))
-        hbox.pack_start(self._size_label, False, False, 10)
+        self._size_entry = Gtk.Entry()
+        self._size_entry.set_text(str(self._font_size))
+        self._size_entry.set_width_chars(3)
+        self._size_entry.connect('activate', self.__entry_cb)
+        hbox.pack_start(self._size_entry, False, False, 5)
 
         self._size_up = Gtk.Button()
         self._size_up.set_can_focus(False)
@@ -272,6 +275,21 @@ class FontSize(Gtk.ToolItem):
                 css_provider_down, Gtk.STYLE_PROVIDER_PRIORITY_USER)
 
         self.show_all()
+    def __entry_cb(self, entry):
+        print(entry)
+        try:
+            self._font_size = int(entry.get_text())
+            if self._font_size > self._font_sizes[-1]:
+                self._font_size = self._font_sizes[-1]
+                entry.set_text(str(self._font_sizes[-1]))
+            elif self._font_size < self._font_sizes[0]:
+                self._font_size = self._font_sizes[0]
+                entry.set_text(str(self._font_sizes[0]))
+        except ValueError:
+            entry.set_text(str(self._font_size))
+        self._size_down.set_sensitive(self._font_size != self._font_sizes[0])
+        self._size_up.set_sensitive(self._font_size != self._font_sizes[-1])
+        self.emit("changed", self._font_size)
 
     def __font_sizes_cb(self, button, increase):
         if self._font_size in self._font_sizes:
@@ -285,10 +303,13 @@ class FontSize(Gtk.ToolItem):
                     i -= 1
 
         else:
-            i = self._font_sizes.index(self._default_size)
+            for font_size in self._font_sizes:
+                if self._font_size < font_size:
+                    i = self._font_sizes.index(font_size)
+                    break
 
         self._font_size = self._font_sizes[i]
-        self._size_label.set_text(str(self._font_size))
+        self._size_entry.set_text(str(self._font_size))
         self._size_down.set_sensitive(i != 0)
         self._size_up.set_sensitive(i < len(self._font_sizes) - 1)
         self.emit("changed", self._font_size)
@@ -304,7 +325,7 @@ class FontSize(Gtk.ToolItem):
                 size = self._font_sizes[-1]
 
         self._font_size = size
-        self._size_label.set_text(str(self._font_size))
+        self._size_entry.set_text(str(self._font_size))
 
         i = self._font_sizes.index(self._font_size)
         self._size_down.set_sensitive(i != 0)

--- a/font.py
+++ b/font.py
@@ -276,7 +276,6 @@ class FontSize(Gtk.ToolItem):
 
         self.show_all()
     def __entry_cb(self, entry):
-        print(entry)
         try:
             self._font_size = int(entry.get_text())
             if self._font_size > self._font_sizes[-1]:

--- a/toolbars.py
+++ b/toolbars.py
@@ -186,11 +186,20 @@ class ViewToolbar(Gtk.Toolbar):
         button_right_line.connect("toggled", self.__show_right_line_changed_cb)
         self.insert(button_right_line, -1)
 
-        self.spinner_right_line = Spinner(conf["right-line-pos"], 1, 150)
-        self.spinner_right_line.set_sensitive(conf["show-right-line"])
-        self.spinner_right_line.connect(
-            "value-changed", self.__right_line_pos_changed_cb)
-        self.insert(self.spinner_right_line, -1)
+        toolItem1 = Gtk.ToolItem()
+        self.spinner_right_line =  Gtk.SpinButton()
+        adjustement = Gtk.Adjustment(
+            value=conf["right-line-pos"],
+            lower=1,
+            upper=150,
+            step_increment=1,
+            page_increment=5,
+            page_size=0,
+        )
+        self.spinner_right_line.set_adjustment(adjustement)
+        self.spinner_right_line.connect('notify::value', self.__right_line_pos_changed_cb)
+        toolItem1.add(self.spinner_right_line)
+        self.insert(toolItem1, -1)
 
         self.insert(utils.make_separator(False), -1)
 
@@ -212,8 +221,9 @@ class ViewToolbar(Gtk.Toolbar):
     def __show_right_line_changed_cb(self, button):
         self.emit("show-right-line-changed", button.get_active())
 
-    def __right_line_pos_changed_cb(self, spinner, value):
-        self.emit("right-line-pos-changed", value)
+    def __right_line_pos_changed_cb(self, spinner, user_data):
+        print(spinner.props.value)
+        self.emit("right-line-pos-changed", spinner.props.value)
 
     def __theme_changed_cb(self, combo, theme):
         self.emit("theme-changed", theme)

--- a/toolbars.py
+++ b/toolbars.py
@@ -222,7 +222,6 @@ class ViewToolbar(Gtk.Toolbar):
         self.emit("show-right-line-changed", button.get_active())
 
     def __right_line_pos_changed_cb(self, spinner, user_data):
-        print(spinner.props.value)
         self.emit("right-line-pos-changed", spinner.props.value)
 
     def __theme_changed_cb(self, combo, theme):


### PR DESCRIPTION
This PR is not complete yet, I created it because I wanted to ask something.

I have updated right line spinner with native Gtk SpinButton. It is working fine as earlier. Only problem is that it is not exactly same aesthetically. Is it fine? Will it be fine if I do same with fontSize SpinButton?

Also, If spinbutton does not look fine and looks bit distorted, then please update your sugar-artwork. I have fixed it.

- [x] Fix right line spinbutton
- [ ] Fix font size spinbutton