### PR TITLE
Add Feature #3: Save current files (and its states)

### DIFF
--- a/CEdit.py
+++ b/CEdit.py
@@ -45,8 +45,8 @@ class CEdit(activity.Activity):
 
     def __init__(self, handle):
         activity.Activity.__init__(self, handle)
-        self.suspend_path = join(activity.get_activity_root(),'tmp')
-        self.index_file = join(self.suspend_path, 'index')
+        self.instance_path = join(activity.get_activity_root(),'instance')
+        self.index_file = join(self.instance_path, 'index')
 
         self.get_conf()
 
@@ -58,7 +58,6 @@ class CEdit(activity.Activity):
         self.toolbar_box.connect("new-page", lambda toolbar: self.new_page())
         self.toolbar_box.connect("chooser-open", self.file_chooser_open)
         self.toolbar_box.connect("chooser-save", self.file_chooser_save)
-        self.toolbar_box.connect("suspend", self.suspend)
         self.toolbar_box.connect("print-file", self.print_file)
         self.toolbar_box.connect("undo", self.undo)
         self.toolbar_box.connect("redo", self.redo)
@@ -128,7 +127,7 @@ class CEdit(activity.Activity):
 
         self.vbox.pack_start(self.notebook, True, True, 2)
         if os.path.exists(self.index_file):
-            self.suspend_wake()
+            self.instance_wake()
         else:
             self.new_page()
         button_add.show()
@@ -232,32 +231,14 @@ class CEdit(activity.Activity):
         file_chooser.connect("open-file", self._open_file_from_chooser)
         file_chooser.show_all()
 
-    def suspend(self, widget):
-        x = 0
-        views = self.notebook.get_children()
-
-        with open(self.index_file,'w') as f:
-            for scrolled in views:
-                view = scrolled.get_children()[0]
-                name = view.get_file()
-                if not name:
-                    name = ''
-                path = join(self.suspend_path, str(x))
-                f.write(name)
-                view.save_file_suspend(path)
-                if not name or x != len(views) - 1:
-                    f.write('\n')
-                x+=1
-        self.close()
-
-    def suspend_wake(self):
+    def instance_wake(self):
         with open(self.index_file, 'r') as f:
             path_list = [path.strip() for path in f.readlines()]
 
         os.remove(self.index_file)
         for x in range(len(path_list)):
-            file_path = join(self.suspend_path, str(x))
-            self._open_file_from_suspend(file_path, path_list[x])
+            file_path = join(self.instance_path, str(x))
+            self._open_file_from_instance(file_path, path_list[x])
             os.remove(file_path)
 
     def file_chooser_save(self, widget, force=False, close=False):
@@ -338,10 +319,10 @@ class CEdit(activity.Activity):
             dialog.run()
             dialog.destroy()
 
-    def _open_file_from_suspend(self, path, path_set):
+    def _open_file_from_instance(self, path, path_set):
         self.new_page(label=path_set.split('/')[-1])
         view = self.get_view(idx=-1)
-        view.set_file_suspend(path, path_set)
+        view.set_file_instance(path, path_set)
 
     def _open_file_from_chooser(self, widget, path):
         children = self.notebook.get_children()
@@ -502,9 +483,24 @@ class CEdit(activity.Activity):
         self.vbox.remove(self.alert)
 
     def write_file(self, file_path):
-        files = []
+        x = 0
+        views = self.notebook.get_children()
 
-        for scrolled in self.notebook.get_children():
+        with open(self.index_file,'w') as f:
+            for scrolled in views:
+                view = scrolled.get_children()[0]
+                name = view.get_file()
+                if not name:
+                    name = ''
+                path = join(self.instance_path, str(x))
+                f.write(name)
+                view.save_file_instance(path)
+                if not name or x != len(views) - 1:
+                    f.write('\n')
+                x+=1
+
+        files = []
+        for scrolled in views:
             view = scrolled.get_children()[0]
             if view.get_file():
                 files.append(view.get_file)

--- a/globals.py
+++ b/globals.py
@@ -2,6 +2,9 @@
 
 import os
 from gettext import gettext as _
+import gi
+gi.require_version('Gdk','3.0')
+gi.require_version('GtkSource','3.0')
 
 from gi.repository import Gdk
 from gi.repository import GtkSource

--- a/icons/suspend.svg
+++ b/icons/suspend.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
+	<!ENTITY stroke_color "#010101">
+	<!ENTITY fill_color "#FFFFFF">
+]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="media-playback-stop">
+	<path d="M27.498,5C15.07,5,5,15.075,5,27.499C5,39.924,15.07,50,27.498,50S50,39.924,50,27.499   C50,15.075,39.926,5,27.498,5z M35.349,35.44h-15.7V19.739h15.7V35.44z" display="inline" fill="&fill_color;"/>
+</g></svg>

--- a/toolbars.py
+++ b/toolbars.py
@@ -251,7 +251,6 @@ class ToolbarBox(SugarToolbarbox):
         "show-right-line-changed": (GObject.SIGNAL_RUN_LAST, None, [bool]),
         "right-line-pos-changed": (GObject.SIGNAL_RUN_LAST, None, [int]),
         "theme-changed": (GObject.SIGNAL_RUN_LAST, None, [str]),
-        "suspend": (GObject.SIGNAL_RUN_LAST, None, []),
     }
 
     def __init__(self, activity):
@@ -293,12 +292,6 @@ class ToolbarBox(SugarToolbarbox):
 
         self.toolbar.insert(utils.make_separator(True), -1)
 
-        suspend_button = ToolButton('suspend')
-        suspend_button.set_tooltip(_('Suspend'))
-        suspend_button.connect('clicked', self._suspend_click)
-        self.toolbar.insert(suspend_button, -1)
-        suspend_button.show()
-
         stop_button = StopButton(activity)
         stop_button.props.accelerator = "<Ctrl><Shift>Q"
         self.toolbar.insert(stop_button, -1)
@@ -309,9 +302,6 @@ class ToolbarBox(SugarToolbarbox):
         self.entry_search = toolbar_edit.entry_search
         self.entry_replace = toolbar_edit.entry_replace
         self.spinner_right_line = toolbar_view.spinner_right_line
-
-    def _suspend_click(self, event):
-        self.emit("suspend")
 
     def _chooser_save(self, toolbar, force):
         self.emit("chooser-save", force)

--- a/toolbars.py
+++ b/toolbars.py
@@ -251,6 +251,7 @@ class ToolbarBox(SugarToolbarbox):
         "show-right-line-changed": (GObject.SIGNAL_RUN_LAST, None, [bool]),
         "right-line-pos-changed": (GObject.SIGNAL_RUN_LAST, None, [int]),
         "theme-changed": (GObject.SIGNAL_RUN_LAST, None, [str]),
+        "suspend": (GObject.SIGNAL_RUN_LAST, None, []),
     }
 
     def __init__(self, activity):
@@ -292,6 +293,12 @@ class ToolbarBox(SugarToolbarbox):
 
         self.toolbar.insert(utils.make_separator(True), -1)
 
+        suspend_button = ToolButton('suspend')
+        suspend_button.set_tooltip(_('Suspend'))
+        suspend_button.connect('clicked', self._suspend_click)
+        self.toolbar.insert(suspend_button, -1)
+        suspend_button.show()
+
         stop_button = StopButton(activity)
         stop_button.props.accelerator = "<Ctrl><Shift>Q"
         self.toolbar.insert(stop_button, -1)
@@ -302,6 +309,9 @@ class ToolbarBox(SugarToolbarbox):
         self.entry_search = toolbar_edit.entry_search
         self.entry_replace = toolbar_edit.entry_replace
         self.spinner_right_line = toolbar_view.spinner_right_line
+
+    def _suspend_click(self, event):
+        self.emit("suspend")
 
     def _chooser_save(self, toolbar, force):
         self.emit("chooser-save", force)

--- a/view.py
+++ b/view.py
@@ -204,14 +204,14 @@ class View(GtkSource.View):
             except RuntimeError:
                 pass
 
-    def set_file_suspend(self, suspend_path, path):
-        if os.path.isfile(suspend_path):
-            with open(suspend_path, "r") as file:
+    def set_file_instance(self, instance_path, path):
+        if os.path.isfile(instance_path):
+            with open(instance_path, "r") as file:
                 modified = int(file.readline().strip())
                 text = file.read()
 
             self.buffer.set_text(text)
-            self.buffer.set_language_from_file(suspend_path)
+            self.buffer.set_language_from_file(path)
             self.buffer.begin_not_undoable_action()
             self.buffer.end_not_undoable_action()
             self.buffer.set_modified(bool(modified))
@@ -242,7 +242,7 @@ class View(GtkSource.View):
 
             self.set_editable(writable)
 
-    def save_file_suspend(self, path):
+    def save_file_instance(self, path):
         self.buffer.set_language_from_file(path)
         with open(path, "w") as file:
             file.write(str(int(self.buffer.get_modified()))+ "\n")

--- a/view.py
+++ b/view.py
@@ -204,6 +204,26 @@ class View(GtkSource.View):
             except RuntimeError:
                 pass
 
+    def set_file_suspend(self, suspend_path, path):
+        if os.path.isfile(suspend_path):
+            with open(suspend_path, "r") as file:
+                modified = int(file.readline().strip())
+                text = file.read()
+
+            self.buffer.set_text(text)
+            self.buffer.set_language_from_file(suspend_path)
+            self.buffer.begin_not_undoable_action()
+            self.buffer.end_not_undoable_action()
+            self.buffer.set_modified(bool(modified))
+            if path:
+                self.file = path
+                readable, writable = utils.get_path_access(path)
+            else:
+                writable = True
+
+            self.emit_title_changed()
+            self.set_editable(writable)
+
     def set_file(self, path, _open=True):
         if os.path.isfile(path) and _open:
             with open(path, "r") as file:
@@ -221,6 +241,12 @@ class View(GtkSource.View):
             readable, writable = utils.get_path_access(path)
 
             self.set_editable(writable)
+
+    def save_file_suspend(self, path):
+        self.buffer.set_language_from_file(path)
+        with open(path, "w") as file:
+            file.write(str(int(self.buffer.get_modified()))+ "\n")
+            file.write(self.buffer.get_all_text())
 
     def save_file(self, path):
         self.buffer.set_modified(False)


### PR DESCRIPTION
**Feature added in this PR:** Save current files (and its states)

**Features:**
 1. Clicking on the Suspend Button will save the current state in `cedit.activity/tmp`
 2. Reopening the activity will resume it from the saved state and also delete files created while suspending it.


**Tested on:**
Sugar 0.112. packaged environment (rdesktop). Ubuntu 16.04


**Test cases used:** (to check function of suspend button)
 1. Made three new files and added some text in them. Didn't save any of them. Clicked on suspend
 2. Made five new files and saved two of them. Clicked on suspend
 3. Made four new files and saved two. Modified one of them again. Didn't save this time. Clicked on suspend.
 4. For 1 to 3, reopened the activtiy and clicked on suspend again.
 

**Note:** Function of Stop Button is not changed. This gives the user a choice to save the state or not

@cristian99garcia, kindly review