### PR TITLE
Fix save

### DIFF
--- a/CEdit.py
+++ b/CEdit.py
@@ -173,11 +173,12 @@ class CEdit(activity.Activity):
                     view = self.get_view(idx=-1)
                     view.set_file(jobject.metadata['file_path'])
             else:
-		    # Should an alert be added saying only file instances that have previously been
-		    # saved to journal can be opened?
+                # Should an alert be added saying
+                # only file instances that have
+                # previously been saved to journal can be opened?
                 pass
         except Exception as e:
-            logging.error('_open_from_journal_cb: %s' %(e))
+            logging.error('_open_from_journal_cb: %s' % (e))
 
     def save_to_journal_cb(self, toolbar):
         view = self.get_view()
@@ -190,9 +191,7 @@ class CEdit(activity.Activity):
         else:
             alert = Alert()
             alert.props.title = _('Error')
-            alert.props.msg = _('Please save the file to your \
-                                file system or save the latest changes, \
-                                before saving it as a journal instance')
+            alert.props.msg = _('Please save the file to your file system or save the latest changes, before saving it as a journal instance')
             ok_icon = Icon(icon_name='dialog-ok')
             alert.add_button(
                     Gtk.ResponseType.OK, _('Ok'), icon=ok_icon)
@@ -555,6 +554,7 @@ class CEdit(activity.Activity):
             self.vbox.remove(self.alert)
         else:
             self.remove_alert(widget)
+
     def write_file(self, file_path):
         x = 0
         views = self.notebook.get_children()

--- a/icons/save-to-journal.svg
+++ b/icons/save-to-journal.svg
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="55"
+   height="55"
+   viewBox="0 0 55 55"
+   id="svg2"
+   xml:space="preserve"><metadata
+     id="metadata25"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs33">
+</defs><g
+     transform="matrix(0.75578519,0,0,0.75578519,-4.9396196,-1.2911009)"
+     id="clipping-text"
+     style="fill:none;stroke:#ffffff;stroke-opacity:1;display:block">
+	<g
+   id="g3152"
+   style="fill:none;stroke:#ffffff;stroke-opacity:1;display:inline">
+		<g
+   id="g3154"
+   style="fill:none;stroke:#ffffff;stroke-opacity:1">
+			<polygon
+   points="31.874,6.088 43.818,18.027 43.818,48.914 10.932,48.914 10.932,6.088 "
+   id="polygon3156"
+   style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-opacity:1" />
+			<polyline
+   id="polyline3158"
+   points="43.818,18.027 31.874,18.027 31.874,6.088    "
+   style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-opacity:1" />
+		</g>
+	</g>
+	<line
+   id="line3160"
+   y2="26.25"
+   y1="26.25"
+   x2="36.875"
+   x1="17.875"
+   display="inline"
+   style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-opacity:1;display:inline" />
+	<line
+   id="line3162"
+   y2="33.25"
+   y1="33.25"
+   x2="36.875"
+   x1="17.875"
+   display="inline"
+   style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-opacity:1;display:inline" />
+	<line
+   id="line3164"
+   y2="40.25"
+   y1="40.25"
+   x2="36.875"
+   x1="17.875"
+   display="inline"
+   style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-opacity:1;display:inline" />
+</g><g
+     id="g3830"><g
+       transform="matrix(0.55205508,0,0,0.55205508,75.618464,18.235971)"
+       id="g4382"><g
+         transform="translate(-80.093659,12.220029)"
+         id="g4308"
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"><g
+           id="g4310"
+           style="fill:none;stroke:#ffffff;stroke-opacity:1"><path
+             d="m 6.736,49.002 h 24.52 c 2.225,0 3.439,-1.447 3.439,-3.441 v -27.28 c 0,-1.73 -1.732,-3.441 -3.439,-3.441 h -4.389"
+             id="path4312"
+             style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /></g></g><g
+         transform="translate(-80.093659,12.220029)"
+         id="g4314"
+         style="fill:none;stroke:#ffffff;stroke-opacity:1"><g
+           id="g4316"
+           style="fill:none;stroke:#ffffff;stroke-opacity:1"><path
+             d="m 26.867,38.592 c 0,1.836 -1.345,3.201 -3.441,4.047 L 6.736,49.002 V 14.84 l 16.69,-8.599 c 2.228,-0.394 3.441,0.84 3.441,2.834 v 29.517 z"
+             id="path4318"
+             style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /></g></g><path
+         d="m -70.669659,54.827029 c 0,0 -1.351,-0.543 -2.702,-0.543 -1.351,0 -2.703,0.543 -2.703,0.543"
+         id="path4320"
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><path
+         d="m -70.669659,44.226029 c 0,0 -1.239,-0.543 -2.815,-0.543 -1.577,0 -2.59,0.543 -2.59,0.543"
+         id="path4322"
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><path
+         d="m -70.669659,33.898029 c 0,0 -1.125,-0.544 -2.927,-0.544 -1.802,0 -2.478,0.544 -2.478,0.544"
+         id="path4324"
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /><line
+         id="line4326"
+         y2="23.725029"
+         y1="58.753029"
+         x2="-66.884659"
+         x1="-66.884659"
+         style="fill:none;stroke:#ffffff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1" /></g><g
+       transform="matrix(1,0,0,-1,-30.386573,49.171266)"
+       id="g4770"><g
+         transform="translate(34.0803,-1006.42)"
+         id="g4772"><polyline
+           id="polyline4774"
+           points="51.562,15.306 41.17,16.188 42.053,5.794"
+           style="fill:none;stroke:#ffffff;stroke-width:3.5;stroke-linecap:round;stroke-linejoin:round"
+           transform="matrix(-0.469241,0.469241,-0.469241,-0.469241,66.2906,1019.03)" /><path
+           d="m 39.363241,1033.1291 -0.05636,9.9115 -8.750608,0.067"
+           id="path4776"
+           style="fill:none;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" /></g></g></g></svg>

--- a/icons/suspend.svg
+++ b/icons/suspend.svg
@@ -1,6 +1,0 @@
-<?xml version="1.0" ?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd' [
-	<!ENTITY stroke_color "#010101">
-	<!ENTITY fill_color "#FFFFFF">
-]><svg enable-background="new 0 0 55 55" height="55px" version="1.1" viewBox="0 0 55 55" width="55px" x="0px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" y="0px"><g display="block" id="media-playback-stop">
-	<path d="M27.498,5C15.07,5,5,15.075,5,27.499C5,39.924,15.07,50,27.498,50S50,39.924,50,27.499   C50,15.075,39.926,5,27.498,5z M35.349,35.44h-15.7V19.739h15.7V35.44z" display="inline" fill="&fill_color;"/>
-</g></svg>

--- a/infobar.py
+++ b/infobar.py
@@ -57,7 +57,9 @@ class InfoBar(Gtk.HBox):
         self.set_pos(1, 1)
 
     def set_pos(self, line, column):
-        self.label_pos.set_label(_("Line: %(line)s, Column: %(column)s") % ({'line': line, 'column': column}))
+        self.label_pos \
+            .set_label(_("Line: %(line)s, Column: %(column)s") %
+                   ({'line': line, 'column': column}))
 
     def set_language(self, language):
         if language != _("Plain text"):

--- a/infobar.py
+++ b/infobar.py
@@ -57,7 +57,7 @@ class InfoBar(Gtk.HBox):
         self.set_pos(1, 1)
 
     def set_pos(self, line, column):
-        self.label_pos.set_label(_("Line: %s, Column: %s") % (line, column))
+        self.label_pos.set_label(_("Line: %(line)s, Column: %(column)s") % ({'line': line, 'column': column}))
 
     def set_language(self, language):
         if language != _("Plain text"):

--- a/toolbars.py
+++ b/toolbars.py
@@ -252,7 +252,7 @@ class ToolbarBox(SugarToolbarbox):
         "right-line-pos-changed": (GObject.SIGNAL_RUN_LAST, None, [int]),
         "theme-changed": (GObject.SIGNAL_RUN_LAST, None, [str]),
         "save-to-journal": (GObject.SIGNAL_RUN_LAST, None, []),
-        "open-from-journal" : (GObject.SIGNAL_RUN_LAST, None, []),
+        "open-from-journal": (GObject.SIGNAL_RUN_LAST, None, []),
     }
 
     def __init__(self, activity):
@@ -300,14 +300,16 @@ class ToolbarBox(SugarToolbarbox):
         separator.show()
 
         self._save_to_journal_button = ToolButton('save-to-journal')
-        self._save_to_journal_button.set_tooltip(_('Save current file to Journal'))
+        self._save_to_journal_button \
+            .set_tooltip(_('Save current file to Journal'))
         self._save_to_journal_button.connect('clicked',
                                              self._save_journal)
         self.toolbar.insert(self._save_to_journal_button, -1)
         self._save_to_journal_button.show()
 
         self._open_from_journal_button = ToolButton()
-        self._open_from_journal_button.set_tooltip(_('Open a file from the Journal'))
+        self._open_from_journal_button \
+            .set_tooltip(_('Open a file from the Journal'))
         self._open_from_journal_button.connect('clicked',
                                                self._open_journal)
         self.toolbar.insert(self._open_from_journal_button, -1)
@@ -326,7 +328,7 @@ class ToolbarBox(SugarToolbarbox):
 
     def _save_journal(self, button):
         self.emit("save-to-journal")
-    
+
     def _open_journal(self, button):
         self.emit("open-from-journal")
 

--- a/toolbars.py
+++ b/toolbars.py
@@ -252,6 +252,7 @@ class ToolbarBox(SugarToolbarbox):
         "right-line-pos-changed": (GObject.SIGNAL_RUN_LAST, None, [int]),
         "theme-changed": (GObject.SIGNAL_RUN_LAST, None, [str]),
         "save-to-journal": (GObject.SIGNAL_RUN_LAST, None, []),
+        "open-from-journal" : (GObject.SIGNAL_RUN_LAST, None, []),
     }
 
     def __init__(self, activity):
@@ -305,6 +306,13 @@ class ToolbarBox(SugarToolbarbox):
         self.toolbar.insert(self._save_to_journal_button, -1)
         self._save_to_journal_button.show()
 
+        self._open_from_journal_button = ToolButton()
+        self._open_from_journal_button.set_tooltip(_('Open a file from the Journal'))
+        self._open_from_journal_button.connect('clicked',
+                                               self._open_journal)
+        self.toolbar.insert(self._open_from_journal_button, -1)
+        self._open_from_journal_button.show()
+
         stop_button = StopButton(activity)
         stop_button.props.accelerator = "<Ctrl><Shift>Q"
         self.toolbar.insert(stop_button, -1)
@@ -318,6 +326,9 @@ class ToolbarBox(SugarToolbarbox):
 
     def _save_journal(self, button):
         self.emit("save-to-journal")
+    
+    def _open_journal(self, button):
+        self.emit("open-from-journal")
 
     def _chooser_save(self, toolbar, force):
         self.emit("chooser-save", force)

--- a/toolbars.py
+++ b/toolbars.py
@@ -251,6 +251,7 @@ class ToolbarBox(SugarToolbarbox):
         "show-right-line-changed": (GObject.SIGNAL_RUN_LAST, None, [bool]),
         "right-line-pos-changed": (GObject.SIGNAL_RUN_LAST, None, [int]),
         "theme-changed": (GObject.SIGNAL_RUN_LAST, None, [str]),
+        "save-to-journal": (GObject.SIGNAL_RUN_LAST, None, []),
     }
 
     def __init__(self, activity):
@@ -292,6 +293,18 @@ class ToolbarBox(SugarToolbarbox):
 
         self.toolbar.insert(utils.make_separator(True), -1)
 
+        separator = Gtk.SeparatorToolItem()
+        separator.props.draw = True
+        self.toolbar.insert(separator, -1)
+        separator.show()
+
+        self._save_to_journal_button = ToolButton('save-to-journal')
+        self._save_to_journal_button.set_tooltip(_('Save current file to Journal'))
+        self._save_to_journal_button.connect('clicked',
+                                             self._save_journal)
+        self.toolbar.insert(self._save_to_journal_button, -1)
+        self._save_to_journal_button.show()
+
         stop_button = StopButton(activity)
         stop_button.props.accelerator = "<Ctrl><Shift>Q"
         self.toolbar.insert(stop_button, -1)
@@ -302,6 +315,9 @@ class ToolbarBox(SugarToolbarbox):
         self.entry_search = toolbar_edit.entry_search
         self.entry_replace = toolbar_edit.entry_replace
         self.spinner_right_line = toolbar_view.spinner_right_line
+
+    def _save_journal(self, button):
+        self.emit("save-to-journal")
 
     def _chooser_save(self, toolbar, force):
         self.emit("chooser-save", force)

--- a/utils.py
+++ b/utils.py
@@ -148,6 +148,11 @@ def get_path_name(path):
     return os.path.basename(gfile.get_path())
 
 
+def get_file_name(file_path):
+    file_name = file_path.split('/')[-1]
+    return file_name
+
+
 def set_border_radius(widget, r1=0, r2=0, r3=0, r4=0):
     name = "Gtk" + widget.__class__.__name__
     theme = "%s {border-radius: %dpx %dpx %dpx %dpx;}" % \

--- a/view.py
+++ b/view.py
@@ -245,7 +245,7 @@ class View(GtkSource.View):
     def save_file_instance(self, path):
         self.buffer.set_language_from_file(path)
         with open(path, "w") as file:
-            file.write(str(int(self.buffer.get_modified()))+ "\n")
+            file.write(str(int(self.buffer.get_modified())) + "\n")
             file.write(self.buffer.get_all_text())
 
     def save_file(self, path):


### PR DESCRIPTION
Fixes #2 
The PR is based on @pro-panda 's #7 work.

**Changes**
```
1) CEdit.py
2) infobar.py
3) toolbars.py
4) utils.py
5) suspend.svg (deleted)
6) save-to-journal (added)
```
**Updates**
Adding from @pro-panda 's work, clicking the save-to-journal button, the current file will saved as a separate journal instance. This journal instance can be added back to the activity by clicking the open-from-journal button, which inturn calls an `ObjectChooser` class. On making changes to the current file and saving causes the saved Journal instance to be updated as well. Clicking the save-to-journal after making changes does not create duplicate journal instances, rather the existing instance is deleted and a new instance is created.

Trying to save-to-journal while having unsaved work is not possible and an alert is thrown.

At the present, I have set the `mime-type` of the saved journal instance as `text/plain`, which causes it open with Write-activity, on clicking it separately in the Journal.

I was not able to find a suitable icon for open-from-journal so I have left it blank at the moment.

**Observations**
On running the activity, there is a warning thrown at the start saying that the repository does not contain a LICENSE, despite having one [here](https://github.com/sugarlabs/cedit-activity/blob/master/COPYING)

The repository does not contain any `po/` dir. 

Tested on Ubuntu 18.04 and v0.114 Sugar